### PR TITLE
Update arch/arm/mach-mx6/board-mx6q_sabrelite.c

### DIFF
--- a/arch/arm/mach-mx6/board-mx6q_sabrelite.c
+++ b/arch/arm/mach-mx6/board-mx6q_sabrelite.c
@@ -159,7 +159,7 @@ struct gpio n6w_wl1271_gpios[] __initdata = {
 	{.label = "wl1271_wl_en",	.gpio = N6_WL1271_WL_EN,	.flags = 0},
 };
 
-int is_nitrogen6w(void)
+int __init is_nitrogen6w(void)
 {
 	int ret = gpio_request_array(n6w_wl1271_gpios,
 			ARRAY_SIZE(n6w_wl1271_gpios));


### PR DESCRIPTION
Added missing __init to prevent warning about section mismatch. Also, Github is weird.
