### PR TITLE
Add CAN bus functionality to imx6q-sabresd board.

### DIFF
--- a/arch/arm/boot/dts/imx6q-sabresd.dts
+++ b/arch/arm/boot/dts/imx6q-sabresd.dts
@@ -45,3 +45,12 @@
 &sata {
 	status = "okay";
 };
+
+&flexcan1 {
+
+        pinctrl-names = "default";
+        pinctrl-0 = <&pinctrl_flexcan1_3>;
+        status = "okay";
+
+};
+

--- a/arch/arm/boot/dts/imx6qdl-sabresd.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-sabresd.dtsi
@@ -548,6 +548,7 @@
 	hog {
 		pinctrl_hog_1: hoggrp-1 {
 			fsl,pins = <
+				MX6QDL_PAD_GPIO_19__GPIO4_IO05	0x130b0 /* Enable CAN tranceiver */
 				MX6QDL_PAD_GPIO_4__GPIO1_IO04   0x80000000
 				MX6QDL_PAD_GPIO_5__GPIO1_IO05   0x80000000
 				MX6QDL_PAD_NANDF_D0__GPIO2_IO00 0x80000000

--- a/arch/arm/boot/dts/imx6qdl.dtsi
+++ b/arch/arm/boot/dts/imx6qdl.dtsi
@@ -1206,6 +1206,12 @@
 				MX6QDL_PAD_KEY_ROW2__FLEXCAN1_RX 0x80000000
 			>;
 		};
+		pinctrl_flexcan1_3: flexcan1grp-3 {
+			fsl,pins = <
+				MX6QDL_PAD_GPIO_7__FLEXCAN1_TX   0x1b0b0
+				MX6QDL_PAD_GPIO_8__FLEXCAN1_RX   0x1b0b0
+			>;
+		};
 	};
 
 	flexcan2 {


### PR DESCRIPTION
I tried this with my sabresd board and I can send and receive data through CAN bus.
I thought I could share it with everybody. (It's the first time I do something like this, so be patient with me if I make some mistake with your policy...)