### PR TITLE
mxc_lcdif: add okaya_480x272 panel settings

### DIFF
--- a/drivers/video/mxc/mxc_lcdif.c
+++ b/drivers/video/mxc/mxc_lcdif.c
@@ -48,6 +48,15 @@ static struct fb_videomode lcdif_modedb[] = {
 	FB_SYNC_CLK_LAT_FALL,
 	FB_VMODE_NONINTERLACED,
 	0,},
+	{
+	 /* Okaya 480x272 */
+	 "okaya_480x272", 60, 480, 272, 97786,
+	 .left_margin = 2, .right_margin = 1,
+	 .upper_margin = 3, .lower_margin = 2,
+	 .hsync_len = 41, .vsync_len = 10,
+	 .sync = FB_SYNC_CLK_LAT_FALL,
+	 .vmode = FB_VMODE_NONINTERLACED,
+	 .flag = 0,},
 };
 static int lcdif_modedb_sz = ARRAY_SIZE(lcdif_modedb);
 


### PR DESCRIPTION
Add the panel definition for the default lcd panel in 6x_bootscript.txt
