### PR TITLE
video: remove duplicated inclusion in Kconfig

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -2521,14 +2521,6 @@ if ARCH_MXC
 source "drivers/video/mxc/Kconfig"
 endif
 
-if ARCH_MXC
-source "drivers/video/mxc/Kconfig"
-endif
-
-if ARCH_MXC
-source "drivers/video/mxc/Kconfig"
-endif
-
 if VT
 	source "drivers/video/console/Kconfig"
 endif


### PR DESCRIPTION
Removed duplicate inclusion of mxc/Kconfig, this made menuconfig display three times the same configuration setting.