### PR TITLE
video VIDIO_QBUF ioctl: Check range of index parameter

### DIFF
--- a/drivers/media/platform/mxc/capture/mxc_v4l2_capture.c
+++ b/drivers/media/platform/mxc/capture/mxc_v4l2_capture.c
@@ -2106,6 +2106,10 @@ static long mxc_v4l_do_ioctl(struct file *file,
 		int index = buf->index;
 		pr_debug("   case VIDIOC_QBUF, length=%d\n", buf->length);
 
+		if (index < 0 || index >= FRAME_NUM) {
+			retval = -EINVAL;
+			break;
+		}
 		spin_lock_irqsave(&cam->queue_int_lock, lock_flags);
 		if ((cam->frame[index].buffer.flags & 0x7) ==
 		    V4L2_BUF_FLAG_MAPPED) {


### PR DESCRIPTION
Hi all,

I had a misbehaving program that caused (sometimes) a kernel Oops in VIDIO_QBUF ioctl(). This little patch should avoid that in future (of course I will also fix my program, but in the end it shouldn't Oops)

Best,

- Johannes
