### PR TITLE
ARM64: dts: fsl-imx8mq:  turn on coherent dma for the csi bridge

### DIFF
--- a/arch/arm64/boot/dts/freescale/fsl-imx8mq.dtsi
+++ b/arch/arm64/boot/dts/freescale/fsl-imx8mq.dtsi
@@ -461,6 +461,7 @@
 			<&clk IMX8MQ_CLK_CSI1_ROOT>,
 			<&clk IMX8MQ_CLK_DUMMY>;
 		clock-names = "disp-axi", "csi_mclk", "disp_dcic";
+		dma-coherent;
 		status = "disabled";
 	};
 
@@ -472,6 +473,7 @@
 			<&clk IMX8MQ_CLK_CSI2_ROOT>,
 			<&clk IMX8MQ_CLK_DUMMY>;
 		clock-names = "disp-axi", "csi_mclk", "disp_dcic";
+		dma-coherent;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
this yields a significant improvement in camera framerate

Signed-off-by: Pat Kusbel <pat@kusbel.com>