### PR TITLE
arm64: dts: imx8mm-dwe: disable POWER_FAIL pullup

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mm-dwe.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mm-dwe.dts
@@ -59,8 +59,8 @@
 
 	pinctrl_gpio_keys: gpio_keysgrp {
 		fsl,pins = <
-#define GP_GPIOKEY_POWER_FAIL	<&gpio1 3 GPIO_ACTIVE_LOW>
-			MX8MMN(IOMUXC_GPIO1_IO03_GPIO1_IO3, 0x140)
+#define GP_GPIOKEY_POWER_FAIL	<&gpio1 3 GPIO_ACTIVE_HIGH>
+			MX8MMN(IOMUXC_GPIO1_IO03_GPIO1_IO3, 0x00)
 		>;
 	};
 
@@ -450,7 +450,7 @@
 		power-fail {
 			label = "Power failure";
 			gpios = GP_GPIOKEY_POWER_FAIL;
-			linux,code = <KEY_POWER>;
+			linux,code = <KEY_STOP>;
 			gpio-key,wakeup;
 		};
 	};


### PR DESCRIPTION
This change disables the internal pullup for the POWER_FAIL signal and changes the keycode to KEY_STOP. It also switches to an ACTIVE_HIGH to swap the press/release semantics.