### PR TITLE
arm64: dts: imx8mm-dwe: Reduce CMA from 640 to 256 MiB

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mm-dwe.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mm-dwe.dts
@@ -769,6 +769,16 @@
 };
 
 &resmem {
+
+	/* global autoconfigured region for contiguous allocations */
+	linux,cma {
+		compatible = "shared-dma-pool";
+		reusable;
+		size = <0 0x10000000>;
+		alloc-ranges = <0 0x40000000 0 0x60000000>;
+		linux,cma-default;
+	};
+
 	limit3g@0x100000000 {
 		no-map;
 		reg = <1 0x00000000 0 0x40000000>;


### PR DESCRIPTION
The reduction of total available memory from 2GB to 1GB in addition with a reserved cma region of 640MiB left very few resources available. This PR reduces the size of the reserved cma region from 640 to 256 MiB and also renames the memory limiting statement from 3g to 1g. 