### PR TITLE
char: fsl_otp: clear error bit after reading locked values

### DIFF
--- a/drivers/char/fsl_otp.c
+++ b/drivers/char/fsl_otp.c
@@ -25,6 +25,7 @@
 
 #define HW_OCOTP_CTRL			0x00000000
 #define HW_OCOTP_CTRL_SET		0x00000004
+#define HW_OCOTP_CTRL_CLR		0x00000008
 #define BP_OCOTP_CTRL_WR_UNLOCK		16
 #define BM_OCOTP_CTRL_WR_UNLOCK		0xFFFF0000
 #define BM_OCOTP_CTRL_RELOAD_SHADOWS	0x00000400
@@ -415,6 +416,10 @@ static int otp_wait_busy(u32 flags)
 		c = __raw_readl(otp_base + HW_OCOTP_CTRL);
 		if (!(c & (BM_OCOTP_CTRL_BUSY | BM_OCOTP_CTRL_ERROR | flags)))
 			break;
+		/* Clear error before attempting further OTP accesses */
+		if (c & (BM_OCOTP_CTRL_ERROR | flags))
+			__raw_writel(BM_OCOTP_CTRL_ERROR,
+				     otp_base + HW_OCOTP_CTRL_CLR);
 		cpu_relax();
 	}
 


### PR DESCRIPTION
When reading a "read locked" value from the OCOTP controller on i.MX6
SoC's an error bit is set. This bit has to be cleared by software before
any new write, read or reload access can be issued.

Therefore clear it after we detect such an "locked read".

For "read locked" values 0xBADABADA will be returned and
HW_OCOTP_CTRL[ERROR] will be set.

After this user will not be able to read/write any fuse value, in order to
access any fuse value user has to reboot the device.

Hence this patch has been added to fix the same, so that user can
read and write the fuse value after reading read locked value.

Signed-off-by: Shitalkumar Gandhi <shital_909@yahoo.com>
