### PR TITLE
arm64: dts: imx8mm-em: add LED_COLOR_ID_* properties for lp55231

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mm-em.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mm-em.dts
@@ -10,6 +10,7 @@
 #define IMX8MM
 
 #include "imx8mm.dtsi"
+#include <dt-bindings/leds/common.h>
 /* panel-ltk080a60a004t.dtsi uses our standard irq pin for enable */
 #define GP_MIPI_IRQ(a)		<&gpio1 1 a>
 #define PD_MIPI_IRQ(a)	MX8MM_IOMUXC_GPIO1_IO01_GPIO1_IO1	a
@@ -848,6 +849,7 @@
 			led-cur = /bits/ 8 <0x2f>;
 			max-cur = /bits/ 8 <0xff>;
 			reg = <0x0>;
+			color = <LED_COLOR_ID_BLUE>;
 		};
 
 		led@1 {
@@ -855,6 +857,7 @@
 			led-cur = /bits/ 8 <0x2f>;
 			max-cur = /bits/ 8 <0xff>;
 			reg = <0x1>;
+			color = <LED_COLOR_ID_RED>;
 		};
 
 		led@2 {
@@ -862,6 +865,7 @@
 			led-cur = /bits/ 8 <0x2f>;
 			max-cur = /bits/ 8 <0xff>;
 			reg = <0x2>;
+			color = <LED_COLOR_ID_GREEN>;
 		};
 
 		led@3 {
@@ -869,6 +873,7 @@
 			led-cur = /bits/ 8 <0x2f>;
 			max-cur = /bits/ 8 <0xff>;
 			reg = <0x3>;
+			color = <LED_COLOR_ID_BLUE>;
 		};
 
 		led@4 {
@@ -876,6 +881,7 @@
 			led-cur = /bits/ 8 <0x2f>;
 			max-cur = /bits/ 8 <0xff>;
 			reg = <0x4>;
+			color = <LED_COLOR_ID_RED>;
 		};
 
 		led@5 {
@@ -883,6 +889,7 @@
 			led-cur = /bits/ 8 <0x2f>;
 			max-cur = /bits/ 8 <0xff>;
 			reg = <0x5>;
+			color = <LED_COLOR_ID_GREEN>;
 		};
 
 		led@6 {
@@ -890,6 +897,7 @@
 			led-cur = /bits/ 8 <0x2f>;
 			max-cur = /bits/ 8 <0xff>;
 			reg = <0x6>;
+			color = <LED_COLOR_ID_BLUE>;
 		};
 
 		led@7 {
@@ -897,6 +905,7 @@
 			led-cur = /bits/ 8 <0x2f>;
 			max-cur = /bits/ 8 <0xff>;
 			reg = <0x7>;
+			color = <LED_COLOR_ID_RED>;
 		};
 
 		led@8 {
@@ -904,6 +913,7 @@
 			led-cur = /bits/ 8 <0x2f>;
 			max-cur = /bits/ 8 <0xff>;
 			reg = <0x8>;
+			color = <LED_COLOR_ID_GREEN>;
 		};
 	};
 };


### PR DESCRIPTION
Kernel 5.15 rejects lp55231 channels that do not specify a LED_COLOR_ID_*. This back-ports the upstream DTS change so the lp55231 driver probes correctly on imx8mm-em-based boards (kirkstone and newer BSPs).

Fixes: 5.15 ("lp55231: drop support for unnamed color channels")
Signed-off-by: Jon Powell <jon.powell@ezurio.com>
