### PR TITLE
EZ_INTERNAL: arm64: mt8390-tungsten-smarc: Add HMI carrier support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1486,6 +1486,7 @@ kernel_build(
         "mediatek/mt8390-tungsten-smarc.dtb",
         "mediatek/mt83x0-tungsten-smarc-android.dtb",
         "mediatek/mt83x0-tungsten-smarc-android-dsi-tm070jdhg30.dtb",
+        "mediatek/mt8390-tungsten-smarc-hmi.dtb",
     ],
     outs = [
         "arch/arm64/boot/dts/mediatek/mt8365-evk.dtb",
@@ -1500,6 +1501,7 @@ kernel_build(
         "arch/arm64/boot/dts/mediatek/mt8390-tungsten-smarc.dtb",
         "arch/arm64/boot/dts/mediatek/mt83x0-tungsten-smarc-android.dtb",
         "arch/arm64/boot/dts/mediatek/mt83x0-tungsten-smarc-android-dsi-tm070jdhg30.dtb",
+        "arch/arm64/boot/dts/mediatek/mt8390-tungsten-smarc-hmi.dtb",
         "modules.builtin",
         "modules.builtin.modinfo",
     ],

--- a/arch/arm64/boot/dts/mediatek/mt8390-tungsten-smarc-hmi.dts
+++ b/arch/arm64/boot/dts/mediatek/mt8390-tungsten-smarc-hmi.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 Ezurio LLC
+ */
+/dts-v1/;
+#include "mt8188.dtsi"
+#include "mt83x0-tungsten-smarc.dtsi"
+
+/ {
+	model = "Ezurio Tungsten700 SMARC (MT8390)";
+	compatible = "ezurio,mt8390-tungsten-smarc", "mediatek,mt8390",
+		     "mediatek,mt8188";
+};
+
+/delete-node/ &i2c_mux_smarc_gp_usbc;
+
+&ssusb0 {
+    dr_mode = "otg";
+    usb-role-switch;
+    role-switch-default-mode = "peripheral";
+
+    /delete-node/ connector;
+
+    ports {
+
+		port@0 {
+			reg = <0>;
+			usb_hs_ep: endpoint {
+				remote-endpoint = <&usb_hs_ep>;
+			};
+		};
+
+        /delete-node/ port@1;
+    };
+};


### PR DESCRIPTION
Add DTB for HMI carrier board
Remove USB-C power control (not supported on HMI carrier)

Refs: PROD-44541